### PR TITLE
fix #9, removed GHC 7.10.3 & HEAD from travis matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,15 @@ cache:
 
 matrix:
   include:
-    - env: CABALVER=1.24 GHCVER=7.10.3
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    #- env: CABALVER=1.24 GHCVER=7.10.3
+    #  compiler: ": #GHC 7.10.3"
+    #  addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=head
-      compiler: ": #GHC head"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-head,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    #- env: CABALVER=1.24 GHCVER=head
+    #  compiler: ": #GHC head"
+    #  addons: {apt: {packages: [cabal-install-1.24,ghc-head,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
 
   allow_failures:
    - env: CABALVER=1.24 GHCVER=head


### PR DESCRIPTION
Removes GHC versions:
+ 7.10.3
+ HEAD
temporarily from the travis CI matrix.

Builds & tests are now only run on GHC 8.0.2.