### PR TITLE
Feature/core/convert unify

### DIFF
--- a/DATX021726.cabal
+++ b/DATX021726.cabal
@@ -77,6 +77,7 @@ library
     , template-haskell >= 2.11.0.0
     , comonad == 5
     , pointless-fun == 1.1.0.6
+    , parsec == 3.1.11
   hs-source-dirs:   libsrc
   default-language: Haskell2010
 

--- a/execsrc/Main.hs
+++ b/execsrc/Main.hs
@@ -70,7 +70,7 @@ compileAndContinue compDir gp ss dirOfModelSolutions cont = do
 tryMatchAndFallBack :: FilePath -> SolutionContext FilePath -> Gen String -> EvalM ()
 tryMatchAndFallBack compDir paths gen = do
   -- Get the contents from the arguments supplied
-  convASTs <- (fmap (fmap parseConvUnit)) . (zipContexts paths) <$> readRawContents paths
+  convASTs <- (fmap (fmap parseConv)) . (zipContexts paths) <$> readRawContents paths
 
   -- Convert `(FilePath, Either String AST)` in to an `EvalM AST` by throwing the parse error
   -- and alerting the user of what file threw the parse error on failure

--- a/libsrc/CoreS/ConvBack.hs
+++ b/libsrc/CoreS/ConvBack.hs
@@ -23,6 +23,7 @@ module CoreS.ConvBack (
   -- * Types
     HoleSum (..)
   , LJSynConv
+  , Repr
   -- * Classes
   , ToLJSyn
   -- * Operations

--- a/libsrc/CoreS/Convert.hs
+++ b/libsrc/CoreS/Convert.hs
@@ -16,30 +16,56 @@
  - Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  -}
 
-{-# LANGUAGE LambdaCase, TupleSections, TemplateHaskell #-}
+{-# LANGUAGE LambdaCase, TupleSections, TemplateHaskell
+  , FlexibleInstances, TypeFamilies, TypeFamilyDependencies #-}
 
-module CoreS.Convert where
+-- | Conversion to CoreS.AST from Langauge.Java.Syntax (hence: S).
+module CoreS.Convert (
+  -- * Types
+    ConvErr
+  , CConv
+  , Repr
+  -- * Classes
+  , ToCoreS
+  -- * Operations
+  , toCoreS
+  ) where
 
 import Safe (headMay)
 import Prelude hiding (LT, GT, EQ)
-import Control.Monad (unless)
+import Control.Monad (unless, (>=>))
 import Data.Maybe (isNothing)
 import Data.List (nub)
 
 import Debug.Trace.LocationTH (__LOCATION__)
 
-import qualified Language.Java.Syntax as S
-
 import Util.List (isPermEq)
 
+import qualified Language.Java.Syntax as S
 import CoreS.AST
 
 --------------------------------------------------------------------------------
--- Conversion:
+-- Conversion computation type:
 --------------------------------------------------------------------------------
 
 type ConvErr = String
 type CConv a = Either ConvErr a
+
+--------------------------------------------------------------------------------
+-- Conversion class:
+--------------------------------------------------------------------------------
+
+-- | Models the conversion to CoreS.AST.
+class ToCoreS t where
+  -- | The corresponding data type in CoreS.AST.
+  type Repr t = (r :: *) | r -> t
+
+  -- | Convert from S. The conversion is partial due to possible holes.
+  toCoreS :: t -> CConv (Repr t)
+
+--------------------------------------------------------------------------------
+-- Conversion DSL:
+--------------------------------------------------------------------------------
 
 unimpl :: Show x => String -> x -> CConv y
 unimpl prefix x = Left $ unwords [prefix, show x, "is not supported yet!"]
@@ -47,20 +73,42 @@ unimpl prefix x = Left $ unwords [prefix, show x, "is not supported yet!"]
 ensure :: Show x => String -> x -> Bool -> CConv ()
 ensure loc x cond = unless cond $ unimpl loc x
 
+toCoreSM :: (Traversable f, ToCoreS t) => f t -> CConv (f (Repr t))
+toCoreSM = mapM toCoreS
+
+(<-$) :: ToCoreS t => (Repr t -> b) -> t -> CConv b
+(<-$) f = fmap f . toCoreS
+
+(<-*) :: ToCoreS t => CConv (Repr t -> b) -> t -> CConv b
+(<-*) f x = f <*> toCoreS x
+
+(<=$) :: (Traversable f, ToCoreS t) => (f (Repr t) -> b) -> f t -> CConv b
+(<=$) f = fmap f . toCoreSM
+
+(<=*) :: (Traversable f, ToCoreS t) => CConv (f (Repr t) -> b) -> f t -> CConv b
+(<=*) f x = f <*> toCoreSM x
+
+(<~*) :: (Traversable g, Traversable f, ToCoreS t)
+      => CConv (g (f (Repr t)) -> b) -> g (f t) -> CConv b
+(<~*) f x = f <*> mapM toCoreSM x
+
+infixl 4 <-$, <-*, <=$, <=*, <~*
+
 --------------------------------------------------------------------------------
 -- Conversion, Types:
 --------------------------------------------------------------------------------
 
-convPTyp :: S.PrimType -> PrimType
-convPTyp = \case
-  S.BooleanT -> BoolT
-  S.ByteT    -> ByteT
-  S.ShortT   -> ShortT
-  S.IntT     -> IntT
-  S.LongT    -> LongT
-  S.CharT    -> CharT
-  S.FloatT   -> FloatT
-  S.DoubleT  -> DoubleT
+instance ToCoreS S.PrimType where
+  type Repr S.PrimType = PrimType
+  toCoreS = pure . \case
+    S.BooleanT -> BoolT
+    S.ByteT    -> ByteT
+    S.ShortT   -> ShortT
+    S.IntT     -> IntT
+    S.LongT    -> LongT
+    S.CharT    -> CharT
+    S.FloatT   -> FloatT
+    S.DoubleT  -> DoubleT
 
 strTPrefix = S.ClassType $ ((, []) . S.Ident) <$> ["java", "lang", "String"]
 strT       = S.ClassType $ ((, []) . S.Ident) <$> ["String"]
@@ -69,49 +117,49 @@ convRTyp :: S.RefType -> CConv Type
 convRTyp = \case
   S.ClassRefType ct |
     ct `elem` [strT, strTPrefix] -> pure StringT
-  S.ArrayType    t               -> ArrayT <$> convTyp t
+  S.ArrayType    t               -> ArrayT <-$ t
   x                              -> unimpl $__LOCATION__ x
 
-convTyp :: S.Type -> CConv Type
-convTyp = \case
-  S.PrimType t -> pure $ PrimT $ convPTyp t
-  S.RefType  t -> convRTyp t
+instance ToCoreS S.Type where
+  type Repr S.Type = Type
+  toCoreS = \case
+    S.PrimType t -> PrimT <-$ t
+    S.RefType  t -> convRTyp t
 
-convId :: S.Ident -> Ident
-convId (S.Ident i) = Ident i
+instance ToCoreS S.Ident where
+  type Repr S.Ident = Ident
+  toCoreS = \case
+    S.Ident i -> pure $ Ident i
 
-convName :: S.Name -> Name
-convName (S.Name is) = Name $ convId <$> is
+instance ToCoreS S.Name where
+  type Repr S.Name = Name
+  toCoreS = \case
+    S.Name is -> Name <=$ is
 
 --------------------------------------------------------------------------------
 -- Conversion, Expression:
 --------------------------------------------------------------------------------
 
-convLit :: S.Literal -> CConv Expr
-convLit = pure . ELit . \case
-  S.Int     i -> Int     i
-  S.Word    w -> Word    w
-  S.Float   f -> Float   f
-  S.Double  d -> Double  d
-  S.Boolean b -> Boolean b
-  S.Char    c -> Char    c
-  S.String  s -> String  s
-  S.Null      -> Null
-
-convUna :: S.Exp -> (Expr -> y) -> CConv y
-convUna e ctor = ctor <$> convExp e
-
-convBin :: S.Exp -> S.Exp -> (Expr -> Expr -> y) -> CConv y
-convBin l r ctor = ctor <$> convExp l <*> convExp r
+instance ToCoreS S.Literal where
+  type Repr S.Literal = Literal
+  toCoreS = pure . \case
+    S.Int     i -> Int     i
+    S.Word    w -> Word    w
+    S.Float   f -> Float   f
+    S.Double  d -> Double  d
+    S.Boolean b -> Boolean b
+    S.Char    c -> Char    c
+    S.String  s -> String  s
+    S.Null      -> Null
 
 convNum :: S.Exp -> S.Exp -> NumOp -> CConv Expr
-convNum l r op = convBin l r $ ENum op
+convNum l r op = ENum op <-$ l <-* r
 
 convCmp :: S.Exp -> S.Exp -> CmpOp -> CConv Expr
-convCmp l r op = convBin l r $ ECmp op
+convCmp l r op = ECmp op <-$ l <-* r
 
 convLog :: S.Exp -> S.Exp -> LogOp -> CConv Expr
-convLog l r op = convBin l r $ ELog op
+convLog l r op = ELog op <-$ l <-* r
 
 convBOp :: S.Exp -> S.Exp -> S.Op -> CConv Expr
 convBOp l r = \case
@@ -135,37 +183,20 @@ convBOp l r = \case
   S.CAnd    -> convLog l r LAnd
   S.COr     -> convLog l r LOr
 
-convStep :: S.Exp -> StepOp -> CConv Expr
-convStep e op = convUna e $ EStep op
-
 convOne :: Show a => [a] -> CConv a
 convOne = \case [x] -> pure x
                 xs  -> unimpl $__LOCATION__ xs
 
-convExpN :: S.Name -> CConv Expr
-convExpN n@(S.Name ns) = EVar . LVName . convId <$> convOne ns
+instance ToCoreS S.VarInit where
+  type Repr S.VarInit = VarInit
+  toCoreS = \case
+    S.InitExp    e -> InitExpr <-$ e
+    S.InitArray ai -> InitArr  <-$ ai
 
-convArrAcc :: S.ArrayIndex -> CConv Expr
-convArrAcc (S.ArrayIndex e eis) =
-  EVar <$> (LVArray <$> convExp e <*> mapM convExp eis)
-
-convArrCreate :: S.Type -> [S.Exp] -> Int -> CConv Expr
-convArrCreate t ls lex = EArrNew <$> convTyp t
-                                 <*> mapM convExp ls
-                                 <*> pure (toInteger lex)
-
-convVarInit :: S.VarInit -> CConv VarInit
-convVarInit = \case
-  S.InitExp    e -> InitExpr <$> convExp e
-  S.InitArray ai -> InitArr  <$> convArrInit ai
-
-convArrInit :: S.ArrayInit -> CConv ArrayInit
-convArrInit (S.ArrayInit ai) = ArrayInit <$> mapM convVarInit ai
-
-convArrCreateI :: S.Type -> Int -> S.ArrayInit -> CConv Expr
-convArrCreateI t dl ai = EArrNewI <$> convTyp t
-                                  <*> pure (toInteger dl)
-                                  <*> convArrInit ai
+instance ToCoreS S.ArrayInit where
+  type Repr S.ArrayInit = ArrayInit
+  toCoreS = \case
+    S.ArrayInit ai -> ArrayInit <=$ ai
 
 printLn :: Name
 printLn = Name $ Ident <$> ["System", "out", "println"]
@@ -173,48 +204,46 @@ printLn = Name $ Ident <$> ["System", "out", "println"]
 convApp :: S.MethodInvocation -> CConv Expr
 convApp = \case
   S.MethodCall n args -> do
-    args' <- mapM convExp args
-    case convName n of
+    args' <- toCoreSM args
+    n'    <- toCoreS n
+    case n' of
       m | m == printLn -> ESysOut <$> maybe (unimpl $__LOCATION__ args')
                                             pure (headMay args')
         | otherwise    -> pure $ EMApp m args'
   x -> unimpl $__LOCATION__ x
 
 convArrIx :: S.ArrayIndex -> CConv Expr
-convArrIx (S.ArrayIndex a is) =
-  EVar <$> (LVArray <$> convExp a <*> mapM convExp is)
-
-convNLhs :: S.Name -> CConv Expr
-convNLhs n = case convName n of
-  Name is -> EVar . LVName <$> convOne is
+convArrIx (S.ArrayIndex a is) = EVar <$> (LVArray <-$ a <=* is)
 
 convAssign :: S.Lhs -> S.AssignOp -> S.Exp -> CConv Expr
 convAssign lv op e = case lv of
-  S.NameLhs   n -> convNLhs  n
+  S.NameLhs   n -> toCoreS n >>= \(Name is) -> EVar . LVName <$> convOne is
   S.ArrayLhs ai -> convArrIx ai
   x             -> unimpl $__LOCATION__ x
 
-convExp :: S.Exp -> CConv Expr
-convExp = \case
-  S.Lit                 lit -> convLit lit
-  S.ArrayCreate    t ls lex -> convArrCreate t ls lex
-  S.ArrayCreateInit t dl ai -> convArrCreateI t dl ai
-  S.MethodInv    mi         -> convApp mi
-  S.ArrayAccess  ai         -> convArrAcc ai
-  S.ExpName       n         -> convExpN n
-  S.PostIncrement e         -> convStep e PostInc
-  S.PostDecrement e         -> convStep e PostDec
-  S.PreIncrement  e         -> convStep e PreInc
-  S.PreDecrement  e         -> convStep e PreDec
-  S.PrePlus       e         -> convUna e EPlus
-  S.PreMinus      e         -> convUna e EMinus
-  S.PreBitCompl   e         -> convUna e EBCompl
-  S.PreNot        e         -> convUna e ENot
-  S.Cast        t e         -> ECast <$> convTyp t <*> convExp e
-  S.BinOp     l o r         -> convBOp l r o
-  S.Cond      c i e         -> ECond <$> convExp c <*> convExp i <*> convExp e
-  S.Assign   lv o e         -> convAssign lv o e
-  x                         -> unimpl $__LOCATION__ x
+instance ToCoreS S.Exp where
+  type Repr S.Exp = Expr
+  toCoreS = \case
+    S.Lit                 lit -> ELit <-$ lit
+    S.ArrayCreate    t ls lex -> EArrNew  <-$ t <=* ls <*> pure (toInteger lex)
+    S.ArrayCreateInit t dl ai -> EArrNewI <-$ t <*> pure (toInteger dl) <-* ai
+    S.MethodInv    mi         -> convApp mi
+    S.ArrayAccess
+      (S.ArrayIndex e eis)    -> EVar <$> (LVArray <-$ e <=* eis)
+    S.ExpName (S.Name ns)     -> convOne ns >>= (EVar . LVName <-$)
+    S.PostIncrement e         -> EStep PostInc <-$ e
+    S.PostDecrement e         -> EStep PostDec <-$ e
+    S.PreIncrement  e         -> EStep PreInc  <-$ e
+    S.PreDecrement  e         -> EStep PreDec  <-$ e
+    S.PrePlus       e         -> EPlus         <-$ e
+    S.PreMinus      e         -> EMinus        <-$ e
+    S.PreBitCompl   e         -> EBCompl       <-$ e
+    S.PreNot        e         -> ENot          <-$ e
+    S.Cast        t e         -> ECast <-$ t <-* e
+    S.BinOp     l o r         -> convBOp l r o
+    S.Cond      c i e         -> ECond <-$ c <-* i <-* e
+    S.Assign   lv o e         -> convAssign lv o e
+    x                         -> unimpl $__LOCATION__ x
 
 --------------------------------------------------------------------------------
 -- Conversion, Statement:
@@ -226,135 +255,142 @@ convVM = \case
   [S.Final] -> pure VMFinal
   x         -> unimpl $__LOCATION__ x
 
-convVMTyp :: [S.Modifier] -> S.Type -> CConv VMType
-convVMTyp ms t = VMType <$> convVM ms <*> convTyp t
+instance ToCoreS ([S.Modifier], S.Type) where
+  type Repr ([S.Modifier], S.Type) = VMType
+  toCoreS = \case
+    (ms, t) -> VMType <$> convVM ms <-* t
 
-convForInit :: S.ForInit -> CConv ForInit
-convForInit = \case
-  S.ForLocalVars ms t vds -> FIVars  <$> convTVVDecl ms t vds
-  S.ForInitExps  es       -> FIExprs <$> mapM convExp es
+instance ToCoreS S.ForInit where
+  type Repr S.ForInit = ForInit
+  toCoreS = \case
+    S.ForLocalVars mds t vds -> FIVars  <-$ ((mds, t), vds)
+    S.ForInitExps  es        -> FIExprs <=$ es
 
-convMay :: (x -> CConv y) -> Maybe x -> CConv (Maybe y)
-convMay cv = maybe (pure Nothing) $ fmap pure . cv
-
-getVDICnt :: S.VarDeclId -> Integer
+getVDICnt :: S.VarDeclId -> CConv Integer
 getVDICnt = \case
-  S.VarId _          -> 0
-  S.VarDeclArray vdi -> 1 + getVDICnt vdi
+  S.VarId _          -> pure 0
+  S.VarDeclArray vdi -> (1+) <$> getVDICnt vdi
 
-getVDIId :: S.VarDeclId -> Ident
+getVDIId :: S.VarDeclId -> CConv Ident
 getVDIId = \case
-  S.VarId i          -> convId i
+  S.VarId i          -> toCoreS i
   S.VarDeclArray vdi -> getVDIId vdi
 
-convVDeclId :: S.VarDeclId -> VarDeclId
-convVDeclId vdi = case getVDICnt vdi of
-  0 -> VarDId $ getVDIId vdi
-  n -> VarDArr (getVDIId vdi) (getVDICnt vdi)
+instance ToCoreS S.VarDeclId where
+  type Repr S.VarDeclId = VarDeclId
+  toCoreS vdi = getVDICnt vdi >>= \case
+    0 -> VarDId  <$> getVDIId vdi
+    n -> VarDArr <$> getVDIId vdi <*> getVDICnt vdi
 
-convVDecl :: S.VarDecl -> CConv VarDecl
-convVDecl (S.VarDecl vdi mvi) =
-  VarDecl <$> pure (convVDeclId vdi) <*> convMay convVarInit mvi
+instance ToCoreS S.VarDecl where
+  type Repr S.VarDecl = VarDecl
+  toCoreS = \case
+    S.VarDecl vdi mvi -> VarDecl <-$ vdi <=* mvi
 
-convTVVDecl :: [S.Modifier] -> S.Type -> [S.VarDecl] -> CConv TypedVVDecl
-convTVVDecl mds t vds = TypedVVDecl <$> convVMTyp mds t <*> mapM convVDecl vds
+instance ToCoreS (([S.Modifier], S.Type), [S.VarDecl]) where
+  type Repr (([S.Modifier], S.Type), [S.VarDecl]) = TypedVVDecl
+  toCoreS = \case
+    (vmt, vds) -> TypedVVDecl <-$ vmt <=* vds
 
-convBlock :: S.Block -> CConv Block
-convBlock (S.Block bs) = Block <$> mapM convBStmt bs
+instance ToCoreS S.Block where
+  type Repr S.Block = Block
+  toCoreS = \case
+    S.Block bs -> Block <=$ bs
 
-convBStmt :: S.BlockStmt -> CConv Stmt
-convBStmt = \case
-  S.BlockStmt s         -> convStmt s
-  S.LocalVars mds t vds -> SVars <$> convTVVDecl mds t vds
-  x                     -> unimpl $__LOCATION__ x
+instance ToCoreS S.BlockStmt where
+  type Repr S.BlockStmt = Stmt
+  toCoreS = \case
+    S.BlockStmt s         -> convStmt s
+    S.LocalVars mds t vds -> SVars <-$ ((mds, t), vds)
+    x                     -> unimpl $__LOCATION__ x
 
-convSwitchL :: S.SwitchLabel -> CConv SwitchLabel
-convSwitchL = \case
-  S.SwitchCase e -> SwitchCase <$> convExp e
-  S.Default      -> pure Default
+instance ToCoreS S.SwitchLabel where
+  type Repr S.SwitchLabel = SwitchLabel
+  toCoreS = \case
+    S.SwitchCase e -> SwitchCase <-$ e
+    S.Default      -> pure Default
 
-convSwitchB :: S.SwitchBlock -> CConv SwitchBlock
-convSwitchB (S.SwitchBlock sl bs) =
-  SwitchBlock <$> convSwitchL sl <*> (Block <$> mapM convBStmt bs)
+instance ToCoreS S.SwitchBlock where
+  type Repr S.SwitchBlock = SwitchBlock
+  toCoreS = \case
+    S.SwitchBlock sl bs -> SwitchBlock <-$ sl <*> (Block <=$ bs)
 
+-- Can't be an instance due to injectivity:
 convStmt :: S.Stmt -> CConv Stmt
 convStmt = \case
-  S.Empty                   -> pure SEmpty
-  S.StmtBlock b             -> SBlock  <$> convBlock b
-  S.IfThen c si             -> SIf     <$> convExp c <*> convStmt si
-  S.IfThenElse c si se      -> SIfElse <$> convExp c <*> convStmt si
-                                                     <*> convStmt se
-  S.While c si              -> SWhile  <$> convExp c <*> convStmt si
-  S.Do si c                 -> SDo     <$> convExp c <*> convStmt si
-  S.BasicFor mfi mc mus si  -> SForB   <$> convMay convForInit mfi
-                                       <*> convMay convExp mc
-                                       <*> convMay (mapM convExp) mus
-                                       <*> convStmt si
-  S.EnhancedFor ms t i e si -> SForE   <$> convVMTyp ms t
-                                       <*> pure (convId i)
-                                       <*> convExp e
-                                       <*> convStmt si
-  S.ExpStmt e               -> SExpr   <$> convExp e
-  S.Switch e sbs            -> SSwitch <$> convExp e <*> mapM convSwitchB sbs
-  S.Return   (Just e)       -> SReturn <$> convExp e
-  S.Return   Nothing        -> pure SVReturn
-  S.Break    Nothing        -> pure SBreak
-  S.Continue Nothing        -> pure SContinue
-  x                         -> unimpl $__LOCATION__ x
+    S.Empty                   -> pure SEmpty
+    S.StmtBlock b             -> SBlock  <-$ b
+    S.IfThen c si             -> SIf     <-$ c <*> convStmt si
+    S.IfThenElse c si se      -> SIfElse <-$ c <*> convStmt si <*> convStmt se
+    S.While c si              -> SWhile  <-$ c <*> convStmt si
+    S.Do si c                 -> SDo     <-$ c <*> convStmt si
+    S.BasicFor mfi mc mus si  -> SForB   <=$ mfi <=* mc <~* mus
+                                               <*> convStmt si
+    S.EnhancedFor ms t i e si -> SForE   <-$ (ms, t) <-* i <-* e
+                                               <*> convStmt si
+    S.ExpStmt e               -> SExpr   <-$ e
+    S.Switch e sbs            -> SSwitch <-$ e <=* sbs
+    S.Return   (Just e)       -> SReturn <-$ e
+    S.Return   Nothing        -> pure SVReturn
+    S.Break    Nothing        -> pure SBreak
+    S.Continue Nothing        -> pure SContinue
+    x                         -> unimpl $__LOCATION__ x
 
 --------------------------------------------------------------------------------
 -- Conversion, Comp unit:
 --------------------------------------------------------------------------------
 
-convArg :: S.FormalParam -> CConv FormalParam
-convArg = \case
-  S.FormalParam ms t False vdi -> do
-    t'   <- convVMTyp ms t
-    pure $ FormalParam t' (convVDeclId vdi)
-  x -> unimpl $__LOCATION__ x
+instance ToCoreS S.FormalParam where
+  type Repr S.FormalParam = FormalParam
+  toCoreS = \case
+    S.FormalParam ms t False vdi -> FormalParam <-$ (ms, t) <-* vdi
+    x -> unimpl $__LOCATION__ x
 
-convMemDecl :: S.MemberDecl -> CConv MemberDecl
-convMemDecl = \case
-  S.MethodDecl mds tps mrt i args exceptt me mb -> do
-    ensure $__LOCATION__ mds     $ isPermEq mds [S.Public, S.Static] &&
-                                   nub mds == mds
-    ensure $__LOCATION__ tps     $ null tps
-    ensure $__LOCATION__ exceptt $ null exceptt
-    ensure $__LOCATION__ me      $ isNothing me
-    case mb of
-      S.MethodBody Nothing  -> unimpl $__LOCATION__ mb
-      S.MethodBody (Just b) -> do
-        let i' = convId i
-        mrt'  <- convMay convTyp mrt
-        args' <- mapM convArg args
-        b'    <- convBlock b
-        pure $ MethodDecl mrt' i' args' b'
-  x -> unimpl $__LOCATION__ x
+instance ToCoreS S.MemberDecl where
+  type Repr S.MemberDecl = MemberDecl
+  toCoreS = \case
+    S.MethodDecl mds tps mrt i args exceptt me mb -> do
+      ensure $__LOCATION__ mds     $ isPermEq mds [S.Public, S.Static] &&
+                                     nub mds == mds
+      ensure $__LOCATION__ tps     $ null tps
+      ensure $__LOCATION__ exceptt $ null exceptt
+      ensure $__LOCATION__ me      $ isNothing me
+      case mb of
+        S.MethodBody Nothing  -> unimpl $__LOCATION__ mb
+        S.MethodBody (Just b) -> MethodDecl <=$ mrt <-* i <=* args <-* b
+    x -> unimpl $__LOCATION__ x
 
-convDecl :: S.Decl -> CConv Decl
-convDecl = \case
-  S.MemberDecl md -> MemberDecl <$> convMemDecl md
-  x               -> unimpl $__LOCATION__ x
+instance ToCoreS S.Decl where
+  type Repr S.Decl = Decl
+  toCoreS = \case
+    S.MemberDecl md -> MemberDecl <-$ md
+    x               -> unimpl $__LOCATION__ x
 
-convCBody :: S.ClassBody -> CConv ClassBody
-convCBody (S.ClassBody ds) = ClassBody <$> mapM convDecl ds
+instance ToCoreS S.ClassBody where
+  type Repr S.ClassBody = ClassBody
+  toCoreS = \case
+    S.ClassBody ds -> ClassBody <=$ ds
 
-convCDecl :: S.ClassDecl -> CConv ClassDecl
-convCDecl = \case
-  S.ClassDecl ms i tps ext impls body -> do
-    ensure $__LOCATION__ ms    $ ms == [S.Public]
-    ensure $__LOCATION__ tps   $ null tps
-    ensure $__LOCATION__ ext   $ isNothing ext
-    ensure $__LOCATION__ impls $ null impls
-    ClassDecl (convId i) <$> convCBody body
+instance ToCoreS S.ClassDecl where
+  type Repr S.ClassDecl = ClassDecl
+  toCoreS = \case
+    S.ClassDecl ms i tps ext impls body -> do
+      ensure $__LOCATION__ ms    $ ms == [S.Public]
+      ensure $__LOCATION__ tps   $ null tps
+      ensure $__LOCATION__ ext   $ isNothing ext
+      ensure $__LOCATION__ impls $ null impls
+      ClassDecl <-$ i <-* body
 
-convTypeDecl :: S.TypeDecl -> CConv TypeDecl
-convTypeDecl = \case
-  S.ClassTypeDecl cd -> ClassTypeDecl <$> convCDecl cd
-  x                  -> unimpl $__LOCATION__ x
+instance ToCoreS S.TypeDecl where
+  type Repr S.TypeDecl = TypeDecl
+  toCoreS = \case
+    S.ClassTypeDecl cd -> ClassTypeDecl <-$ cd
+    x                  -> unimpl $__LOCATION__ x
 
-convUnit :: S.CompilationUnit -> CConv CompilationUnit
-convUnit (S.CompilationUnit mpd is tds) = do
-  ensure $__LOCATION__ mpd $ isNothing mpd
-  ensure $__LOCATION__ is  $ null is
-  CompilationUnit <$> mapM convTypeDecl tds
+instance ToCoreS S.CompilationUnit where
+  type Repr S.CompilationUnit = CompilationUnit
+  toCoreS = \case
+    S.CompilationUnit mpd is tds -> do
+      ensure $__LOCATION__ mpd $ isNothing mpd
+      ensure $__LOCATION__ is  $ null is
+      CompilationUnit <=$ tds

--- a/libsrc/CoreS/Parse.hs
+++ b/libsrc/CoreS/Parse.hs
@@ -16,7 +16,16 @@
  - Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  -}
 
-module CoreS.Parse where
+{-# LANGUAGE FlexibleInstances, FlexibleContexts #-}
+
+module CoreS.Parse (
+  -- * Classes
+    LJParser
+  -- * Operations
+  , ljParser
+  , parse
+  , parseConv
+  ) where
 
 import Data.Bifunctor (first)
 import Control.Monad ((>=>))
@@ -24,11 +33,62 @@ import Control.Monad ((>=>))
 import CoreS.AST
 import CoreS.Convert
 
+import Text.Parsec (Parsec)
+import qualified Language.Java.Lexer  as L
 import qualified Language.Java.Parser as P
 import qualified Language.Java.Syntax as S
 
-parseUnit :: String -> CConv S.CompilationUnit
-parseUnit = first show . P.parser P.compilationUnit
+type Mod a = [S.Modifier] -> a
 
-parseConvUnit :: String -> CConv CompilationUnit
-parseConvUnit = parseUnit >=> convUnit
+--------------------------------------------------------------------------------
+-- Parser class:
+--------------------------------------------------------------------------------
+
+-- | Determines the parser for some term of type t in S.
+class LJParser t where
+  -- | Get the parser for the term t.
+  ljParser :: Parsec [L.L L.Token] () t
+
+--------------------------------------------------------------------------------
+-- Operations:
+--------------------------------------------------------------------------------
+
+-- | Parses a term in S.
+parse :: LJParser t => String -> CConv t
+parse = first show . P.parser ljParser
+
+-- | Parses a term in S and then converts it into the corresponding term in
+-- the CoreS.AST.
+parseConv :: (LJParser t, ToCoreS t) => String -> CConv (Repr t)
+parseConv = parse >=> toCoreS
+
+--------------------------------------------------------------------------------
+-- Instances:
+--------------------------------------------------------------------------------
+
+instance LJParser S.CompilationUnit     where ljParser = P.compilationUnit
+instance LJParser S.PackageDecl         where ljParser = P.packageDecl
+instance LJParser S.ImportDecl          where ljParser = P.importDecl
+instance LJParser (Maybe S.TypeDecl)    where ljParser = P.typeDecl
+instance LJParser (Mod S.ClassDecl)     where ljParser = P.classDecl
+instance LJParser (Mod S.InterfaceDecl) where ljParser = P.interfaceDecl
+instance LJParser (Mod S.MemberDecl)    where ljParser = P.memberDecl
+instance LJParser [S.FormalParam]       where ljParser = P.formalParams
+instance LJParser S.FormalParam         where ljParser = P.formalParam
+instance LJParser S.Modifier            where ljParser = P.modifier
+instance LJParser [S.VarDecl]           where ljParser = P.varDecls
+instance LJParser S.VarDecl             where ljParser = P.varDecl
+instance LJParser S.Block               where ljParser = P.block
+instance LJParser S.BlockStmt           where ljParser = P.blockStmt
+instance LJParser S.Stmt                where ljParser = P.stmt
+instance LJParser S.Exp                 where ljParser = P.exp
+instance LJParser S.Literal             where ljParser = P.literal
+instance LJParser S.Type                where ljParser = P.ttype
+instance LJParser S.PrimType            where ljParser = P.primType
+instance LJParser S.RefType             where ljParser = P.refType
+instance LJParser S.ClassType           where ljParser = P.classType
+instance LJParser (Maybe S.Type)        where ljParser = P.resultType
+instance LJParser [S.TypeParam]         where ljParser = P.typeParams
+instance LJParser S.TypeParam           where ljParser = P.typeParam
+instance LJParser S.Name                where ljParser = P.name
+instance LJParser S.Ident               where ljParser = P.ident

--- a/libsrc/CoreS/Parse.hs
+++ b/libsrc/CoreS/Parse.hs
@@ -18,6 +18,7 @@
 
 {-# LANGUAGE FlexibleInstances, FlexibleContexts #-}
 
+-- | Parser language-java and conversion to CoreS.AST.
 module CoreS.Parse (
   -- * Classes
     LJParser


### PR DESCRIPTION
Accomplishes:
+ Unification of all converters in `CoreS.Convert` into a type class.
+ Parsing of terms in `language-java`
+ `parse >=> toCoreS` for any type `representable in both `language-java` and `CoreS.AST`... There is now nothing special about `CompilationUnit`.
+ `CoreS.ConvBack`: small fix... now exporting `Repr`