### PR TITLE
Feature/core/new

### DIFF
--- a/libsrc/AlphaR.hs
+++ b/libsrc/AlphaR.hs
@@ -290,10 +290,11 @@ renameExpression expression =
     (ESysOut  expr) -> ESysOut <$> renameExpression expr
     holeExpr -> return holeExpr
 
---Renames a Literal Value
+--Renames a lvalue.
 renameLValue :: LValue -> State Env LValue
 renameLValue lValue = case lValue of
-  (LVName ident) -> LVName <$> newVarName ident
+  (LVName (Name [ident])) -> singVar <$> newVarName ident
+  (LVName x) -> pure lValue -- TODO: Fix logic for this case.
   (LVArray expr exprs) ->
     LVArray
     <$> renameExpression expr

--- a/libsrc/CoreS/AST.hs
+++ b/libsrc/CoreS/AST.hs
@@ -49,6 +49,10 @@ data Name = Name
 
 instance NFData Name
 
+-- | Constructs a Name from a single Ident.
+singName :: Ident -> Name
+singName = Name . pure
+
 --------------------------------------------------------------------------------
 -- Types:
 --------------------------------------------------------------------------------
@@ -70,13 +74,16 @@ instance NFData PrimType
 -- | All possible types that value / expression can be of.
 data Type
   = PrimT {
-      _tPrim :: PrimType -- ^ A primitive type.
+      _tPrim  :: PrimType -- ^ A primitive type.
     }
-  | StringT              -- ^ A String type.
+  | StringT               -- ^ A String type.
+  | NullT                 -- ^ Type of the null literal, can't be declared.
+  | ClassType {
+      _tClass :: Name     -- ^ A user defined or built-in class type.
+    }
   | ArrayT {
-      _tType :: Type     -- ^ An array type of some other type.
+      _tType  :: Type     -- ^ An array type of some other type.
     }
-  | NullT                -- ^ Type of the null literal, can't be declared.
   deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 
 instance NFData Type
@@ -251,7 +258,7 @@ instance NFData Literal
 -- to be a location in memory.
 data LValue
   = LVName {
-      _lvId    :: Ident   -- ^ Simple variable identifier.
+      _lvId    :: Name   -- ^ A variable / property / static field identifier.
     }
   | LVArray {
       _lvExpr  :: Expr   -- ^ An expression yielding an array.
@@ -263,6 +270,12 @@ data LValue
   deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 
 instance NFData LValue
+
+-- | Constructs an LValue from a single Ident.
+-- This needn't be a local variable, but could instead be a static field
+-- of some static import, or in the future a static field of the same class.
+singVar :: Ident -> LValue
+singVar = LVName . singName
 
 --------------------------------------------------------------------------------
 -- Variable & Array initialization:
@@ -356,6 +369,10 @@ data Expr
   | EMApp {
       _eName     :: Name        -- ^ Name of method to apply.
     , _eExprs    :: [Expr]
+    }
+  | EInstNew {                  -- Constructs a new object of _eName type.
+      _eName     :: Name        -- ^ Name of the type to be instantiated.
+    , _eExprs    :: [Expr]      -- ^ Zero or more exprs to pass to constructor.
     }
   | EArrNew {
       _eDefT     :: Type        -- ^ Base-type of array to construct.

--- a/libsrc/CoreS/ASTUnitypeUtils.hs
+++ b/libsrc/CoreS/ASTUnitypeUtils.hs
@@ -28,11 +28,12 @@ import Data.Maybe (maybeToList)
 -- if `dependsOn y x == False` then `y; x;` and `x; y;`
 -- should be semantically identical
 dependsOn :: AST -> AST -> Bool
-dependsOn SEmpty _ = False
-dependsOn _ SEmpty = False
-dependsOn (MethodDecl _ _ _ _) (MethodDecl _ _ _ _) = False
-dependsOn (MemberDecl _) (MemberDecl _) = False
-dependsOn y x = True
+dependsOn = curry $ \case
+  (SEmpty,        _            ) -> False
+  (_,             SEmpty       ) -> False
+  (MethodDecl {}, MethodDecl {}) -> False
+  (MemberDecl {}, MemberDecl {}) -> False
+  (y,             x            ) -> True
 
 nbrOfStatements :: AST -> Int
 nbrOfStatements a = 1 + case a of
@@ -53,7 +54,8 @@ nbrOfStatements a = 1 + case a of
   EBCompl a             -> nbrOfStatements a
   EPlus   a             -> nbrOfStatements a
   EMinus  a             -> nbrOfStatements a
-  EMApp _ as            -> sm as
+  EMApp    _ as         -> sm as
+  EInstNew _ as         -> sm as
   EArrNew  _ as _       -> sm as
   EArrNewI _ _ as       -> sm as
   ESysOut a             -> nbrOfStatements a

--- a/libsrc/Norm/VarDecl.hs
+++ b/libsrc/Norm/VarDecl.hs
@@ -146,7 +146,7 @@ viToExpr vmt vdi vi = do
 
 -- | VarDeclId to an LValue.
 vdiToLV :: VarDeclId -> NormE LValue
-vdiToLV = mayDecline . fmap LVName . (^? vdiIdent)
+vdiToLV = mayDecline . fmap singVar . (^? vdiIdent)
 
 splitVD' :: VMType -> VarDecl -> NormArr [Stmt]
 splitVD' vmt vd = withError $ \_ -> splitVD vmt vd


### PR DESCRIPTION
Fixes #135 by :

+ adding `ClassType` to `CoreS.AST ( Type )`.
+ changing `LVName Ident` into `LVName Name`.
+ adding `EInstNew Name [Expr]` in `Expr`.
+ making sure these additions work with conversions and the things we already have.

Fixes #140 by:
+ making `AST` into a record.
+ deriving lenses + prisms for it.