### PR TITLE
Feature/norm/compund assignment

### DIFF
--- a/DATX021726.cabal
+++ b/DATX021726.cabal
@@ -68,6 +68,7 @@ library
     , Norm.ElimDead
     , Norm.AllNormalizations
     , Norm.DoWToWhile
+    , Norm.CompAssignment
     , AlphaR
 
   build-depends:
@@ -128,7 +129,7 @@ executable JAA
                     -threaded
                     -rtsopts
 
-executable Eval 
+executable Eval
   main-is:          Eval.hs
   build-depends:
       base >=4.8 && < 5
@@ -168,6 +169,7 @@ Test-Suite tests
     , Norm.ElimRedundantTest
     , Norm.ElimDeadTest
     , Norm.DoWToWhileTest
+    , Norm.CompAssignmentTest
   default-language: Haskell2010
   build-depends:
       tasty

--- a/Test/Norm/CompAssignmentTest.hs
+++ b/Test/Norm/CompAssignmentTest.hs
@@ -1,0 +1,33 @@
+{- DATX02-17-26, automated assessment of imperative programs.
+ - Copyright, 2017, see AUTHORS.md.
+ -
+ - This program is free software; you can redistribute it and/or
+ - modify it under the terms of the GNU General Public License
+ - as published by the Free Software Foundation; either version 2
+ - of the License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU General Public License for more details.
+ -
+ - You should have received a copy of the GNU General Public License
+ - along with this program; if not, write to the Free Software
+ - Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ -}
+
+-- | Test for eliminating redundant blocks and statements
+module Norm.CompAssignmentTest (
+    allTests
+  ) where
+
+import Norm.NormTestUtil
+import Norm.CompAssignment
+
+normalizers :: NormalizerCU
+normalizers = [ normCompAss ]
+
+allTests :: TestTree
+allTests = testGroup "Norm.CompAssignment tests"
+  [ normTestDir "compundassignment_unittest_1" "compassignment" 1 normalizers
+  ]

--- a/Test/NormalizationTests.hs
+++ b/Test/NormalizationTests.hs
@@ -30,6 +30,7 @@ import qualified Norm.NormForTest as NoFo
 import qualified Norm.ElimRedundantTest as ElRe
 import qualified Norm.ElimDeadTest as ElDe
 import qualified Norm.DoWToWhileTest as DoWh
+import qualified Norm.CompAssignmentTest as CoAs
 
 instance Show (NormalizationRuleT m a) where
   show = (^. name)
@@ -42,6 +43,7 @@ allTests = testGroup "Normalization tests"
   , ElRe.allTests
   , ElDe.allTests
   , DoWh.allTests
+  , CoAs.allTests
   ]
 
 normStrat :: TestTree

--- a/Test/fixture/norm/compassignment/Expected1.java
+++ b/Test/fixture/norm/compassignment/Expected1.java
@@ -1,0 +1,57 @@
+public class C{
+
+  public static void main(String[] args) {
+    int x = 0;
+    x = x + 1;
+    x = x - 1;
+    x = x * 1;
+    x = x / 1;
+    for(int i = 0; i < 3; i++){
+      x = x + 1;
+      x = x - 1;
+      x = x * 1;
+      x = x / 1;
+    }
+
+    if(true){
+      x = x + 1;
+      x = x - 1;
+      x = x * 1;
+      x = x / 1;
+    }
+    else{
+      x = x + 1;
+      x = x - 1;
+      x = x * 1;
+      x = x / 1;
+    }
+
+    if(true){
+      x = x + 1;
+      x = x - 1;
+      x = x * 1;
+      x = x / 1;
+    }
+
+    while(true){
+      x = x + 1;
+      x = x - 1;
+      x = x * 1;
+      x = x / 1;
+    }
+
+    {
+      x = x + 1;
+      x = x - 1;
+      x = x * 1;
+      x = x / 1;
+    }
+    do {
+      x = x + 1;
+      x = x - 1;
+      x = x * 1;
+      x = x / 1;
+    }while(true);
+  }
+
+}

--- a/Test/fixture/norm/compassignment/Source1.java
+++ b/Test/fixture/norm/compassignment/Source1.java
@@ -1,0 +1,57 @@
+public class C{
+
+  public static void main(String[] args) {
+    int x = 0;
+    x += 1;
+    x -= 1;
+    x *= 1;
+    x /= 1;
+    for(int i = 0; i < 3; i++){
+      x += 1;
+      x -= 1;
+      x *= 1;
+      x /= 1;
+    }
+
+    if(true){
+      x += 1;
+      x -= 1;
+      x *= 1;
+      x /= 1;
+    }
+    else{
+      x += 1;
+      x -= 1;
+      x *= 1;
+      x /= 1;
+    }
+
+    if(true){
+      x += 1;
+      x -= 1;
+      x *= 1;
+      x /= 1;
+    }
+
+    while(true){
+      x += 1;
+      x -= 1;
+      x *= 1;
+      x /= 1;
+    }
+
+    {
+      x += 1;
+      x -= 1;
+      x *= 1;
+      x /= 1;
+    }
+    do {
+      x += 1;
+      x -= 1;
+      x *= 1;
+      x /= 1;
+    }while(true);
+  }
+
+}

--- a/libsrc/Norm/CompAssignment.hs
+++ b/libsrc/Norm/CompAssignment.hs
@@ -18,10 +18,10 @@
 
 {-# LANGUAGE LambdaCase #-}
 
+-- | Normalizer for transforming compound assignment in to assignment.
 module Norm.CompAssignment (normCompAss) where
 
 import Norm.NormCS
-
 
 stage :: Int
 stage = 6
@@ -29,10 +29,10 @@ stage = 6
 -- | x <op>= y => x = x <op> y
 normCompAss :: NormCUR
 normCompAss = makeRule' "compund_assign.expr.compund_assign_to_assign" [stage]
-                            execCompAss
+                        execCompAss
 
 -- | executes normalization of compund assignments
 execCompAss :: NormCUA
 execCompAss = normEvery $ \case
-  EOAssign lv op expr -> change (EAssign lv (ENum op (EVar lv) expr))
-  x                 -> unique x
+  EOAssign lv op expr -> change $ EAssign lv $ ENum op (EVar lv) expr
+  x                   -> unique x

--- a/libsrc/Norm/CompAssignment.hs
+++ b/libsrc/Norm/CompAssignment.hs
@@ -1,0 +1,38 @@
+{- DATX02-17-26, automated assessment of imperative programs.
+ - Copyright, 2017, see AUTHORS.md.
+ -
+ - This program is free software; you can redistribute it and/or
+ - modify it under the terms of the GNU General Public License
+ - as published by the Free Software Foundation; either version 2
+ - of the License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU General Public License for more details.
+ -
+ - You should have received a copy of the GNU General Public License
+ - along with this program; if not, write to the Free Software
+ - Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ -}
+
+{-# LANGUAGE LambdaCase #-}
+
+module Norm.CompAssignment (normCompAss) where
+
+import Norm.NormCS
+
+
+stage :: Int
+stage = 6
+
+-- | x <op>= y => x = x <op> y
+normCompAss :: NormCUR
+normCompAss = makeRule' "compund_assign.expr.compund_assign_to_assign" [stage]
+                            execCompAss
+
+-- | executes normalization of compund assignments
+execCompAss :: NormCUA
+execCompAss = normEvery $ \case
+  EOAssign lv op expr -> change (EAssign lv (ENum op (EVar lv) expr))
+  x                 -> unique x


### PR DESCRIPTION
Turns all compound assignments into regular assignments with the operand expression on the right side.
Fixes #153.