### PR TITLE
Feature/norm/EStep

### DIFF
--- a/DATX021726.cabal
+++ b/DATX021726.cabal
@@ -106,7 +106,8 @@ library
     , deepseq
   hs-source-dirs:   libsrc
   default-language: Haskell2010
-  ghc-options:      -O2
+  ghc-options:      
+    -- -O2
 
 executable JAA
   main-is:          Main.hs
@@ -129,9 +130,10 @@ executable JAA
     , random == 1.1
   hs-source-dirs:   execsrc
   default-language: Haskell2010
-  ghc-options:      -O2
-                    -threaded
-                    -rtsopts
+  ghc-options:
+    -- -O2
+    -threaded
+    -rtsopts
 
 executable Eval
   main-is:          Eval.hs
@@ -152,9 +154,10 @@ executable Eval
     , random == 1.1
   hs-source-dirs:   execsrc
   default-language: Haskell2010
-  ghc-options:      -O2
-                    -threaded
-                    -rtsopts
+  ghc-options:
+    -- -O2
+    -threaded
+    -rtsopts
 
 Test-Suite tests
   type:            exitcode-stdio-1.0
@@ -194,37 +197,43 @@ benchmark strategies
   type:             exitcode-stdio-1.0
   hs-source-dirs:   bench
   main-is:          BenchStrategies.hs
-  build-depends:    base,
-                    deepseq,
-                    ghc-prim,
-                    criterion,
-                    DATX021726
-  ghc-options:      -O2
-                    -threaded
-                    -rtsopts
+  build-depends:
+      base
+    , deepseq
+    , ghc-prim
+    , criterion
+    , DATX021726
+  ghc-options:
+    -O2
+    -threaded
+    -rtsopts
 
 benchmark alpha
   type:             exitcode-stdio-1.0
   hs-source-dirs:   bench
   main-is:          BenchAlpha.hs
-  build-depends:    base,
-                    deepseq,
-                    ghc-prim,
-                    criterion,
-                    DATX021726
-  ghc-options:      -O2
-                    -threaded
-                    -rtsopts
+  build-depends:
+      base
+    , deepseq
+    , ghc-prim
+    , criterion
+    , DATX021726
+  ghc-options:
+    -O2
+    -threaded
+    -rtsopts
 
 benchmark convert
   type:             exitcode-stdio-1.0
   hs-source-dirs:   bench
   main-is:          BenchConvert.hs
-  build-depends:    base,
-                    deepseq,
-                    ghc-prim,
-                    criterion,
-                    DATX021726
-  ghc-options:      -O2
-                    -threaded
-                    -rtsopts
+  build-depends:
+      base
+    , deepseq
+    , ghc-prim
+    , criterion
+    , DATX021726
+  ghc-options:
+    -- -O2
+    -threaded
+    -rtsopts

--- a/DATX021726.cabal
+++ b/DATX021726.cabal
@@ -73,6 +73,7 @@ library
     , Norm.CompAssignment
     , Norm.ForIndex
     , Norm.FloatToDouble
+    , Norm.StepOp
     , AlphaR
 
   build-depends:
@@ -179,6 +180,7 @@ Test-Suite tests
     , Norm.DoWToWhileTest
     , Norm.CompAssignmentTest
     , Norm.FloatToDoubleTest
+    , Norm.StepOpTest
     , EvalTest
   default-language: Haskell2010
   build-depends:
@@ -197,6 +199,7 @@ benchmark strategies
   type:             exitcode-stdio-1.0
   hs-source-dirs:   bench
   main-is:          BenchStrategies.hs
+  default-language: Haskell2010
   build-depends:
       base
     , deepseq
@@ -212,6 +215,7 @@ benchmark alpha
   type:             exitcode-stdio-1.0
   hs-source-dirs:   bench
   main-is:          BenchAlpha.hs
+  default-language: Haskell2010
   build-depends:
       base
     , deepseq
@@ -227,6 +231,7 @@ benchmark convert
   type:             exitcode-stdio-1.0
   hs-source-dirs:   bench
   main-is:          BenchConvert.hs
+  default-language: Haskell2010
   build-depends:
       base
     , deepseq

--- a/Test/Norm/StepOpTest.hs
+++ b/Test/Norm/StepOpTest.hs
@@ -1,0 +1,34 @@
+{- DATX02-17-26, automated assessment of imperative programs.
+ - Copyright, 2017, see AUTHORS.md.
+ -
+ - This program is free software; you can redistribute it and/or
+ - modify it under the terms of the GNU General Public License
+ - as published by the Free Software Foundation; either version 2
+ - of the License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU General Public License for more details.
+ -
+ - You should have received a copy of the GNU General Public License
+ - along with this program; if not, write to the Free Software
+ - Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ -}
+
+-- | Tests for Norm.StepOp.
+module Norm.StepOpTest (
+    allTests
+  ) where
+
+import Norm.NormTestUtil
+import Norm.StepOp
+
+normalizers :: NormalizerCU
+normalizers = [ normStepFor
+              , normStepSExpr
+              , normStepExpr
+              ]
+
+allTests :: TestTree
+allTests = normTestsDir "Norm.StepOp" "stepop" [normalizers]

--- a/Test/NormalizationTests.hs
+++ b/Test/NormalizationTests.hs
@@ -25,15 +25,16 @@ import Control.Lens
 import Norm.NormM
 import NormalizationStrategies
 
-import qualified Norm.VarDeclTest as NoVD
-import qualified Norm.NormForTest as NoFo
-import qualified Norm.ElimRedundantTest as ElRe
-import qualified Norm.ElimDeadTest as ElDe
-import qualified Norm.IfElseEmptyTest as IfEE
-import qualified Norm.DoWToWhileTest as DoWh
+import qualified Norm.VarDeclTest        as NoVD
+import qualified Norm.NormForTest        as NoFo
+import qualified Norm.ElimRedundantTest  as ElRe
+import qualified Norm.ElimDeadTest       as ElDe
+import qualified Norm.IfElseEmptyTest    as IfEE
+import qualified Norm.DoWToWhileTest     as DoWh
 import qualified Norm.CompAssignmentTest as CoAs
-import qualified Norm.ForIndexTest as ForI
-import qualified Norm.FloatToDoubleTest as FlDo
+import qualified Norm.ForIndexTest       as ForI
+import qualified Norm.FloatToDoubleTest  as FlDo
+import qualified Norm.StepOpTest         as StOp
 
 allTests :: TestTree
 allTests = testGroup "Normalization tests"
@@ -47,6 +48,7 @@ allTests = testGroup "Normalization tests"
   , CoAs.allTests
   , ForI.allTests
   , FlDo.allTests
+  , StOp.allTests
   ]
 
 normStrat :: TestTree

--- a/Test/fixture/norm/stepop/Expected1.java
+++ b/Test/fixture/norm/stepop/Expected1.java
@@ -1,0 +1,23 @@
+public class C {
+  public static void dummy(int i) {}
+  public static void main (String[] args) {
+    int i = 0;
+
+    // SExpr:
+    i = i + 1;
+    i = i - 1;
+    i = i + 1;
+    i = i - 1;
+
+    // For:
+    for ( int j = 0, k = 0; j < 10;
+          j = j + 1, k = 0, i = i + 1, j = j - 1, i = i - 1) {}
+
+    // In expressions:
+    dummy( ((i = i + 1) - 1)
+         * ((i = i - 1) + 1)
+         * (i = i + 1)
+         * (i = i - 1)
+        );
+  }
+}

--- a/Test/fixture/norm/stepop/Source1.java
+++ b/Test/fixture/norm/stepop/Source1.java
@@ -1,0 +1,23 @@
+public class C {
+  public static void dummy(int i) {}
+  public static void main (String[] args) {
+    int i = 0;
+
+    // SExpr:
+    i++;
+    i--;
+    ++i;
+    --i;
+
+    // For:
+    for ( int j = 0, k = 0; j < 10;
+          j++, k = 0, ++i, --j, i--) {}
+
+    // In expressions:
+    dummy( i++
+         * i--
+         * ++i
+         * --i
+        );
+  }
+}

--- a/libsrc/Norm/AllNormalizations.hs
+++ b/libsrc/Norm/AllNormalizations.hs
@@ -12,13 +12,16 @@ import Norm.IfElseEmpty
 import Norm.DoWToWhile
 import Norm.FloatToDouble
 import Norm.ForIndex
+import Norm.StepOp
 
 normalizations :: Normalizer CompilationUnit
-normalizations = [ alphaRenaming, normForIndex, normForToWhile, normCompAss,
-                   normMoveForTVD, normSingleTVDs, normVDIArrLeft,
-                   normSplitInit, normVDTop ,normSortT,
-                   normFlattenBlock, normEmptyBlock, normFilterEmpty,
-                   normSingleton, normDeadIf, normDeadDo,
-                   normDeadWhile, normDeadFor, normDoWToWhile,
-                   normIESiEmpty, normIESeEmpty, normIEBothEmpty,
-                   normFloatToDoubleVars, normFloatToDoubleRet]
+normalizations = [ alphaRenaming, normForIndex, normForToWhile, normCompAss
+                 , normMoveForTVD, normSingleTVDs, normVDIArrLeft
+                 , normSplitInit, normVDTop ,normSortT
+                 , normFlattenBlock, normEmptyBlock, normFilterEmpty
+                 , normSingleton, normDeadIf, normDeadDo
+                 , normDeadWhile, normDeadFor, normDoWToWhile
+                 , normIESiEmpty, normIESeEmpty, normIEBothEmpty
+                 , normStepFor, normStepSExpr, normStepExpr
+                 , normFloatToDoubleVars, normFloatToDoubleRet
+                 ]

--- a/libsrc/Norm/NormM.hs
+++ b/libsrc/Norm/NormM.hs
@@ -52,6 +52,8 @@ import Control.Monad.Morph (MFunctor, MMonad, hoist)
 import Control.Lens (transformMOf, transformMOnOf, traverseOf, (^?), Getting)
 import Data.Data.Lens (uniplate, biplate)
 
+import Data.Function.Pointless ((.:))
+
 import Test.QuickCheck (Arbitrary, CoArbitrary, arbitrary)
 
 import Class.HasError (HasError, toEither)
@@ -235,7 +237,7 @@ mayDecline = maybe decline pure
 -- or 'decline' to normalize if there was no pure value.
 -- Just use this as you would use (^?).
 (^??) :: MonadError () m => s -> Getting (First a) s a -> NormT m a
-(^??) s g = mayDecline $ s ^? g
+(^??) = mayDecline .: (^?)
 
 --------------------------------------------------------------------------------
 -- Collecting terms:

--- a/libsrc/Norm/NormM.hs
+++ b/libsrc/Norm/NormM.hs
@@ -18,7 +18,8 @@
 
 {-# LANGUAGE DeriveDataTypeable, DeriveGeneric, GeneralizedNewtypeDeriving
   , TemplateHaskell, TupleSections, StandaloneDeriving
-  , MultiParamTypeClasses, KindSignatures, FlexibleContexts #-}
+  , MultiParamTypeClasses, KindSignatures, FlexibleContexts
+  , RankNTypes #-}
 
 -- | Normalizer monad and utilities.
 module Norm.NormM (
@@ -131,6 +132,25 @@ type NormArr a = a -> Norm a
 -- | NormArr: kleisli arrow for NormW w.
 type NormArrW w a = a -> NormW w a
 
+-- | NormArrE: kleisli arrow for NormE.
+type NormArrE a = a -> NormE a
+
+--------------------------------------------------------------------------------
+-- Kleisli arrows with Applicative inside:
+--------------------------------------------------------------------------------
+
+-- | NormArrT: kleisli arrow for NormT m.
+type ANormArrT m c a = Applicative c => a -> NormT m (c a)
+
+-- | NormArr: kleisli arrow for Norm.
+type ANormArr c a = Applicative c => a -> Norm (c a)
+
+-- | NormArr: kleisli arrow for NormW w.
+type ANormArrW w c a = Applicative c => a -> NormW w (c a)
+
+-- | NormArrE: kleisli arrow for NormE.
+type ANormArrE c a = Applicative c => a -> NormE (c a)
+
 --------------------------------------------------------------------------------
 -- Runners:
 --------------------------------------------------------------------------------
@@ -210,17 +230,40 @@ instance (Monad m, Arbitrary a) => Arbitrary (NormT m a) where
 -- Failing without a term (MonadError as base):
 --------------------------------------------------------------------------------
 
--- | NormE: A failible normalizing computation.
-type NormE a = NormT (Either ()) a
+-- | EU is isomorphic to Maybe.
+type EU = Either ()
 
--- | 'withError'': 'withError' specialized to Either () as base monad.
-withError' :: Monad m => NormArrT (Either ()) a -> NormArrT m a
+-- | NormE: A failible normalizing computation.
+type NormE a = NormT EU a
+
+-- | 'withError'': 'withError' specialized to EU as base monad.
+withError' :: Monad m => NormArrT EU a -> NormArrT m a
 withError' = withError
+
+-- | 'withErrorA'': 'withErrorA' specialized to EU as base monad.
+withErrorA' :: (Monad m, Applicative c) => ANormArrT EU c a -> ANormArrT m c a
+withErrorA' = withErrorA
 
 -- | 'withError': run a normalizer that can error.
 -- If an error occurs, the starting term will be returned.
 withError :: (HasError e m, Monad m') => NormArrT m a -> NormArrT m' a
-withError f a = rebase $ either (const $ unique a) normMake $
+withError = withErrorG id
+
+-- | 'withErrorA': run a normalizer that can error.
+-- The normalizer is given a term but yields an applicative of the term.
+-- If an error occurs, the starting term will be returned
+-- as a pure applicative value.
+withErrorA :: (HasError e m, Monad m', Applicative c)
+           => ANormArrT m c a -> ANormArrT m' c a
+withErrorA = withErrorG pure
+
+-- | 'withErrorG': run a normalizer that can error.
+-- If an error occurs, the starting term,
+-- applied to the second argument, which is a function, will be returned.
+-- This is the generalized form of the 'withError' functions.
+withErrorG :: (HasError e m, Monad m')
+           => (a -> b) -> (a -> NormT m b) -> a -> NormT m' b
+withErrorG fe f a = rebase $ either (const $ unique $ fe a) normMake $
                                 toEither $ runNT (f a)
 
 -- | 'decline' to normalize. This is useful when you don't have a term to give
@@ -245,7 +288,7 @@ mayDecline = maybe decline pure
 
 type NormWT w m a = WriterT w (NormT m) a
 type NormW  w a   = NormWT w Identity a
-type NormWE w a   = NormWT w (Either ()) a
+type NormWE w a   = NormWT w EU a
 
 zeroError :: (HasError e m, Monoid w, Monad n) => NormWT w m a -> NormWT w n ()
 zeroError m = case toEither $ runNT $ runWriterT m of

--- a/libsrc/Norm/StepOp.hs
+++ b/libsrc/Norm/StepOp.hs
@@ -24,7 +24,6 @@ module Norm.StepOp (
     normStepFor
   , normStepSExpr
   , normStepExpr
-  , changeStep
   ) where
 
 import Control.Lens ((%%~))
@@ -62,7 +61,7 @@ normStepExpr = makeRule' "unsafe.step_op.expr" [stage + 1] execStepExpr
 --------------------------------------------------------------------------------
 
 execStepFor :: NormCUA
-execStepFor = normEvery $ (sForEPost %%~) . traverse . traverseJ $ withErrorA' $
+execStepFor = normEvery $ (sForEPost %%~) . traverse . traverseJErr $
   extStep >=> change . exprIntoExprStmts . changeStep
 
 --------------------------------------------------------------------------------
@@ -70,7 +69,7 @@ execStepFor = normEvery $ (sForEPost %%~) . traverse . traverseJ $ withErrorA' $
 --------------------------------------------------------------------------------
 
 execStepSExpr :: NormCUA
-execStepSExpr = normEvery $ traverseJ $ withErrorA' $
+execStepSExpr = normEvery $ traverseJErr $
   (^?? _SExpr) >=> extStep >=> change . exprIntoStmts . changeStep
 
 --------------------------------------------------------------------------------
@@ -78,8 +77,7 @@ execStepSExpr = normEvery $ traverseJ $ withErrorA' $
 --------------------------------------------------------------------------------
 
 execStepExpr :: NormCUA
-execStepExpr = normEvery $ withError' $
-  extStep >=> change . changeStep
+execStepExpr = normEvery $ withError' $ extStep >=> change . changeStep
 
 --------------------------------------------------------------------------------
 -- Common Logic:

--- a/libsrc/Norm/StepOp.hs
+++ b/libsrc/Norm/StepOp.hs
@@ -61,8 +61,6 @@ normStepExpr = makeRule' "unsafe.step_op.expr" [stage + 1] execStepExpr
 -- step_op.stmt.for:
 --------------------------------------------------------------------------------
 
-u = undefined
-
 execStepFor :: NormCUA
 execStepFor = normEvery $ (sForEPost %%~) . traverse . traverseJ $ withErrorA' $
   extStep >=> change . exprIntoExprStmts . changeStep

--- a/libsrc/Norm/StepOp.hs
+++ b/libsrc/Norm/StepOp.hs
@@ -1,0 +1,122 @@
+{- DATX02-17-26, automated assessment of imperative programs.
+ - Copyright, 2017, see AUTHORS.md.
+ -
+ - This program is free software; you can redistribute it and/or
+ - modify it under the terms of the GNU General Public License
+ - as published by the Free Software Foundation; either version 2
+ - of the License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU General Public License for more details.
+ -
+ - You should have received a copy of the GNU General Public License
+ - along with this program; if not, write to the Free Software
+ - Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ -}
+
+{-# LANGUAGE LambdaCase #-}
+
+-- | Normalizers for simplifying EStep / StepOp.
+module Norm.StepOp (
+  -- * Normalizers
+    normStepFor
+  , normStepSExpr
+  , normStepExpr
+  , changeStep
+  ) where
+
+import Control.Lens ((%%~))
+
+import Util.Monad (traverseJ)
+import Norm.NormCS
+
+-- TODO allocate stages. At the moment chosen arbitrarily.
+stage :: Int
+stage = 1
+
+--------------------------------------------------------------------------------
+-- Exported Rules:
+--------------------------------------------------------------------------------
+
+-- | Simplifies stepping expressions in the update part of basic for loops.
+-- > for ( init ; cond ; i++, ... )  =>  for ( init ; cond ; i = i + 1 )
+normStepFor :: NormCUR
+normStepFor = makeRule' "step_op.stmt.for" [stage] execStepFor
+
+-- | Simplifies stepping expressions in a free statement expression.
+-- > i++;  =>  i = i + 1;
+normStepSExpr :: NormCUR
+normStepSExpr = makeRule' "step_op.stmt.sexpr" [stage] execStepSExpr
+
+-- | Simplifies stepping expressions in any expression.
+-- > x - i++   =>   x - ((i = i + 1) - 1)
+-- It is important that this run AFTER
+-- "step_op.stmt.sexpr" and "step_op.stmt.for"
+normStepExpr :: NormCUR
+normStepExpr = makeRule' "unsafe.step_op.expr" [stage + 1] execStepExpr
+
+--------------------------------------------------------------------------------
+-- step_op.stmt.for:
+--------------------------------------------------------------------------------
+
+u = undefined
+
+execStepFor :: NormCUA
+execStepFor = normEvery $ (sForEPost %%~) . traverse . traverseJ $ withErrorA' $
+  extStep >=> change . exprIntoExprStmts . changeStep
+
+--------------------------------------------------------------------------------
+-- step_op.stmt.sexpr:
+--------------------------------------------------------------------------------
+
+execStepSExpr :: NormCUA
+execStepSExpr = normEvery $ traverseJ $ withErrorA' $
+  (^?? _SExpr) >=> extStep >=> change . exprIntoStmts . changeStep
+
+--------------------------------------------------------------------------------
+-- step_op.expr:
+--------------------------------------------------------------------------------
+
+execStepExpr :: NormCUA
+execStepExpr = normEvery $ withError' $
+  extStep >=> change . changeStep
+
+--------------------------------------------------------------------------------
+-- Common Logic:
+--------------------------------------------------------------------------------
+
+-- | Simplifies (LValue, StepOp) into a simpler form.
+-- > i++ => (i = i + 1) - 1
+-- > i-- => (i = i - 1) + 1
+-- > ++i => i = i + 1
+-- > --i => i = i - 1
+changeStep :: (LValue, StepOp) -> Expr
+changeStep (lv, sop) =
+  -- TODO: definition of one is not semantic preserving and unsafe.
+  -- It will fail in the case of char/byte/short i = 0; i++
+  -- Fix this by inferring the type of LValue.
+  let one = ELit $ Int 1
+      (nop, after) = case sop of
+        PostInc -> (Add, flip (ENum Sub) one)
+        PostDec -> (Sub, flip (ENum Add) one)
+        PreInc  -> (Add, id)
+        PreDec  -> (Sub, id)
+  in after $ EAssign lv $ ENum nop (EVar lv) one
+
+-- | Is a normalization semantic preserving (SP) for EStep ?
+-- For example,
+-- > arr[i++]
+-- Has side effects and will thus not preserve semantics.
+isNormSP :: LValue -> Bool
+isNormSP = \case
+  LVName {}     -> True
+  LVArray a is  -> True -- TODO: analyze purity of constitutents.
+  HoleLValue {} -> False
+
+-- | Extracts the StepOP + LValue of an EStep if possible.
+extStep :: Expr -> NormE (LValue, StepOp)
+extStep = mayDecline . \case
+  EStep op (EVar lv) | isNormSP lv -> pure (lv, op)
+  _                                -> Nothing


### PR DESCRIPTION
+ fixes #157 ,
+ adds `(^??)`, `withErrorG`, `withErrorA`, `withErrorA'`, `traverseJErr` to `Norm.NormM`,
+ adds `traverseS = fmap asum .: traverse`.