### PR TITLE
View Normalized Source

### DIFF
--- a/DATX021726.cabal
+++ b/DATX021726.cabal
@@ -160,6 +160,30 @@ executable Eval
     -threaded
     -rtsopts
 
+executable ViewNorm 
+  main-is:          View.hs 
+  build-depends:
+      base >=4.8 && < 5
+    , lens >= 4.14
+    , directory >= 1.2
+    , ideas >= 1.6
+    , transformers >= 0.5
+    , mtl >= 2.2
+    , filepath >= 1.4
+    , process >= 1.4
+    , optparse-applicative >= 0.13
+    , language-java == 0.2.8
+    , DATX021726
+    , QuickCheck
+    , hint == 0.6.0
+    , random == 1.1
+  hs-source-dirs:   execsrc
+  default-language: Haskell2010
+  ghc-options:
+    -- -O2
+    -threaded
+    -rtsopts
+
 Test-Suite tests
   type:            exitcode-stdio-1.0
   hs-source-dirs:  Test

--- a/execsrc/View.hs
+++ b/execsrc/View.hs
@@ -1,0 +1,26 @@
+module Main where
+
+import System.Environment
+import System.FilePath
+
+import NormalizationStrategies
+import CoreS.AST
+import CoreS.Parse
+import CoreS.ConvBack
+import Norm.AllNormalizations as ALL
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    [studPath] -> do
+      studContents <- readFile studPath
+      putStrLn "FILE CONTENTS BEFORE NORMALIZATION:\n"
+      putStrLn studContents
+      let Right ast = parseConv studContents
+      putStrLn "\nAFTER NORMALIZATION:\n"
+      putStrLn $ either (const "parse error") id $ prettyCore' (normalize ast)
+    _ -> putStrLn "Bad args"
+
+normalize :: CompilationUnit -> CompilationUnit
+normalize = executeNormalizer ALL.normalizations

--- a/modelsolution/uppgift12a/Uppgift12a_4.java
+++ b/modelsolution/uppgift12a/Uppgift12a_4.java
@@ -1,4 +1,4 @@
-public class Uppgift12a_1 {
+public class Uppgift12a_4 {
    public static void main(String[] args) {
 
       double pi = 0;

--- a/modelsolution/uppgift12a/Uppgift12a_6.java
+++ b/modelsolution/uppgift12a/Uppgift12a_6.java
@@ -1,4 +1,4 @@
-public class Uppg12a_6
+public class Uppgift12a_6
 {
   public static void main (String[] args)
   {


### PR DESCRIPTION
Implemented a small tool for viewing a normalized version of a java program.
The program can be run using `cabal run ViewNorm path/to/file.java`